### PR TITLE
Update alarms.py

### DIFF
--- a/src/cloud/aws/utils/alarms.py
+++ b/src/cloud/aws/utils/alarms.py
@@ -166,15 +166,17 @@ class AWSAlarmReader():
 
             # Metric Stat is present in alarms, then the required details details will be fetched from these as well
             # this is useful in the case of compoite alarms
-            for metric in alarm.get('Metrics', []):
-                if 'MetricStat' not in metric:
-                    continue
+            # Commented the below block to fix the issue which is occuring if the resource ( Ex. SQS ) is a part of multimetric alarm.
+            # Than the value (Resource Name - queue_name) is not showing up in the final spreadsheet result, as ideally it should come.
+#             for metric in alarm.get('Metrics', []):
+#                 if 'MetricStat' not in metric:
+#                     continue
 
-                _metric = metric['MetricStat']['Metric']
-                self.set_data_in_mandatory_metrics_map(_metric)
-                self.set_mandatory_metric_with_threshold(_metric)
-                self.capture_alarm_action( alarm['AlarmArn'], alarm['AlarmName'], alarm['AlarmActions'],
-                                           _metric['MetricName'], _metric['Dimensions'])
+#                 _metric = metric['MetricStat']['Metric']
+#                 self.set_data_in_mandatory_metrics_map(_metric)
+#                 self.set_mandatory_metric_with_threshold(_metric)
+#                 self.capture_alarm_action( alarm['AlarmArn'], alarm['AlarmName'], alarm['AlarmActions'],
+#                                            _metric['MetricName'], _metric['Dimensions'])
 
     def read(self):
 


### PR DESCRIPTION
Commented the inner for_loop block of the set_mandatory_metrics_map_for_page() method to fix the issue result of which the entries of  resources which is part of multi metric alarm is not coming in the final spreadsheet, as it is used to compare the resource list with the multi metric alarms after fetching and creating the maps from the response of multi metric alarms.

# Description

Issue: Resources which are part of multi metric alarm are not coming in the final spreadsheet.
Solution: Skip the condition checking of resources with multi metric alarms.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Tested creating the same scenario of the issue in the staging environment. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
